### PR TITLE
Fix issue with max tokens being none

### DIFF
--- a/baserun/instrumentation/openai.py
+++ b/baserun/instrumentation/openai.py
@@ -58,10 +58,9 @@ class OpenAIInstrumentor(BaseInstrumentor):
         span.set_attribute(SpanAttributes.OPENAI_API_TYPE, openai.api_type)
         span.set_attribute(SpanAttributes.LLM_REQUEST_MODEL, kwargs.get("model"))
 
-        if "max_tokens" in kwargs:
-            span.set_attribute(
-                SpanAttributes.LLM_REQUEST_MAX_TOKENS, kwargs.get("max_tokens")
-            )
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            span.set_attribute(SpanAttributes.LLM_REQUEST_MAX_TOKENS, max_tokens)
 
         if "temperature" in kwargs:
             span.set_attribute(


### PR DESCRIPTION
`max_tokens` is set to `None` when using langchain, which causes this to error out.