### PR TITLE
Export the new 'finish' method, just like init

### DIFF
--- a/baserun/__init__.py
+++ b/baserun/__init__.py
@@ -34,6 +34,7 @@ evals = Baserun.evals
 api_key = os.environ.get("BASERUN_API_KEY")
 annotate = Baserun.annotate
 submit_input_variable = Baserun.submit_input_variable
+finish = Baserun.finish
 
 __all__ = [
     "Baserun",
@@ -61,4 +62,5 @@ __all__ = [
     "check_equals",
     "check_includes",
     "submit_input_variable",
+    "finish",
 ]


### PR DESCRIPTION
In https://github.com/baserun-ai/baserun-py/pull/120 a new `finish` function was added to the `Baserun` class to enable callers to wait until the futures had completed before exiting.

This function wasn't added to the main `__init__.py` but has similar utility to the `init` function.

This PR adds `finish` as a top-level exported function.